### PR TITLE
Simplify Examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ import { Component } from '@angular/core';
 @Component({
     template: `
         <h2>Home component header</h2>
-        <loaders-css [loader]="'square-spin'" [loaderClass]="'my-loader'"></loaders-css>
+        <loaders-css loader="square-spin" loaderClass="my-loader"></loaders-css>
     `
 })
 export class HomeComponent {}


### PR DESCRIPTION
The example in the template was using unnecessary input bindings for static values:

    <loaders-css [loader]="'square-spin'" [loaderClass]="'my-loader'"></loaders-css>

Becomes:

    <loaders-css loader="square-spin" loaderClass="my-loader"></loaders-css>